### PR TITLE
Progress 20250421

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vscode/settings.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
     "cSpell.words": [
         "Createcontroller"
+
+    
     ]
 }

--- a/controllers/Createcontroller.php
+++ b/controllers/Createcontroller.php
@@ -3,23 +3,34 @@ require_once __DIR__ . '/../config/config.php';
 require_once __DIR__ . '/../models/Todo.php';
 require_once __DIR__ . '/../helpers/Validation.php';
 
-// フォームのPOSTデータを受け取る
-$title = trim($_POST['title'] ?? '');
-$content = trim($_POST['content'] ?? '');
+class CreateController
+{
+    public function handle(): void
+    {
+        // POSTデータの取得
+        $title = trim($_POST['title'] ?? '');
+        $content = trim($_POST['content'] ?? '');
 
-// バリデーション
-$errors = validateTodoInput($title, $content); // ← IDないバージョン
-if (!empty($errors)) {
-    foreach ($errors as $error) {
-        echo '<p style="color:red;">' . htmlspecialchars($error, ENT_QUOTES, 'UTF-8') . '</p>';
+        // Todoモデルのインスタンス生成
+        $todoModel = new Todo();
+
+        // ToDo数取得
+        $todos = $todoModel->getAllTodos();
+        $todoCount = count($todos);
+
+        // バリデーション
+        $errors = Validation::validateTodoInput($title, $content, $todoCount);
+
+        if (!empty($errors)) {
+            require_once __DIR__ . '/../views/errors/create_error.php';
+            return;
+        }
+
+        // 新規作成処理
+        $todoModel->create($title, $content);
+
+        // 一覧ページへリダイレクト
+        header('Location: /php-0416-training/index.php');
+        exit;
     }
-    echo '<a href="/php-0416-training/views/create.php"><button>戻る</button></a>';
-    exit;
 }
-
-$todoModel = new Todo();
-$todoModel->create($title, $content);
-
-// 一覧ページに戻る
-header('Location: /php-0416-training/index.php');
-exit;

--- a/controllers/Deletecontroller.php
+++ b/controllers/Deletecontroller.php
@@ -1,17 +1,25 @@
 <?php
-error_reporting(E_ALL);
-ini_set('display_errors', 1);
-
 require_once __DIR__ . '/../models/Todo.php';
 
-$todoModel = new Todo();
+class DeleteController
+{
+    public function handle(): void
+    {
+        $id = $_POST['id'] ?? null;
 
-// フォームのデータを取得
-$id = $_POST['id'] ?? null;
+        if (!$id) {
+            header('Location: /php-0416-training/index.php?error=invalid_id');
+            exit;
+        }
 
-// 削除を実行
-$todoModel->delete($id);
+        $todoModel = new Todo();
+        $todoModel->delete($id);
 
-// 一覧ページに戻る
-header('Location: /php-0416-training/index.php');
-exit;
+        header('Location: /php-0416-training/index.php');
+        exit;
+    }
+}
+
+// 実行
+$controller = new DeleteController();
+$controller->handle();

--- a/controllers/Editcontroller.php
+++ b/controllers/Editcontroller.php
@@ -2,21 +2,30 @@
 require_once __DIR__ . '/../config/config.php';
 require_once __DIR__ . '/../models/Todo.php';
 
-$id = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
-if ($id === null || $id === false) {
-    // 不正なIDが入力された → 一覧に戻す
-    header('Location: /php-0416-training/index.php?error=invalid_id');
-    exit;
+class EditController
+{
+    public function handle(): void
+    {
+        $id = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
+
+        if ($id === null || $id === false) {
+            header('Location: /php-0416-training/index.php?error=invalid_id');
+            exit;
+        }
+
+        $todoModel = new Todo();
+        $todo = $todoModel->findById($id);
+
+        if (!$todo) {
+            header('Location: /php-0416-training/index.php?error=not_found');
+            exit;
+        }
+
+        // ビューに渡す
+        require_once __DIR__ . '/../views/edit.php';
+    }
 }
 
-$todoModel = new Todo();
-$todo = $todoModel->findById($id);
-
-if (!$todo) {
-    // 該当IDがない → 一覧に戻す
-    header('Location: /php-0416-training/index.php?error=not_found');
-    exit;
-}
-
-// あとは edit.php を表示
-require_once __DIR__ . '/../views/edit.php';
+// 実行
+$controller = new EditController();
+$controller->handle();

--- a/controllers/ListController.php
+++ b/controllers/ListController.php
@@ -1,0 +1,31 @@
+<?php
+require_once __DIR__ . '/../config/config.php';
+require_once __DIR__ . '/../models/Todo.php';
+require_once __DIR__ . '/../helpers/Validation.php';
+
+class ListController
+{
+    public function handle(): void
+    {
+        $todoModel = new Todo();
+        $todos = $todoModel->getAllTodos();
+        $todoCount = count($todos);
+
+        $errorMessage = '';
+        if (isset($_GET['error'])) {
+            switch ($_GET['error']) {
+                case 'invalid_id':
+                    $errorMessage = 'ERROR：不正なIDが入力されました。';
+                    break;
+                case 'not_found':
+                    $errorMessage = 'ERROR：指定されたToDoは見つかりませんでした。';
+                    break;
+            }
+        }
+
+        require __DIR__ . '/../views/list.php';
+    }
+}
+
+$controller = new ListController();
+$controller->handle();

--- a/controllers/Storecontroller.php
+++ b/controllers/Storecontroller.php
@@ -1,18 +1,33 @@
 <?php
-require_once __DIR__ . '/../models/config.php';
+require_once __DIR__ . '/../config/config.php';
 require_once __DIR__ . '/../models/Todo.php';
 require_once __DIR__ . '/../helpers/Validation.php';
 
-$id = filter_input(INPUT_POST, 'id', FILTER_VALIDATE_INT);
-$title = trim($_POST['title'] ?? '');
-$content = trim($_POST['content'] ?? '');
+class StoreController
+{
+    public function handle(): void
+    {
+        $id = filter_input(INPUT_POST, 'id', FILTER_VALIDATE_INT);
+        $title = trim($_POST['title'] ?? '');
+        $content = trim($_POST['content'] ?? '');
 
-// バリデーション
-$errors = validateTodoInput($id, $title, $content);
-if (!empty($errors)) {
-    foreach ($errors as $error) {
-        echo '<p style="color:red;">' . htmlspecialchars($error, ENT_QUOTES, 'UTF-8') . '</p>';
+        $validator = new Validation();
+        $errors = $validator->validateTodoInput($title, $content);
+
+        if (!empty($errors)) {
+            // エラービューへ
+            require __DIR__ . '/../views/errors/validation_error.php';
+            return;
+        }
+
+        $todoModel = new Todo();
+        $todoModel->update($id, $title, $content);
+
+        header('Location: /php-0416-training/index.php');
+        exit;
     }
-    echo '<a href="/php-0416-training/views/create.php"><button>戻る</button></a>';
-    exit;
 }
+
+// 実行
+$controller = new StoreController();
+$controller->handle();

--- a/controllers/Todocontroller.php
+++ b/controllers/Todocontroller.php
@@ -1,9 +1,19 @@
 <?php
 require_once __DIR__ . '/../models/Todo.php';
 
-$todo = new Todo();
-$todos = $todo->getAllTodos();
-$todoCount = count($todos);
+class TodoController
+{
+    public function handle(): void
+    {
+        $todoModel = new Todo();
+        $todos = $todoModel->getAllTodos();
+        $todoCount = count($todos);
 
-// ビューに渡す（後述の list.php を読み込む）
-require_once __DIR__ . '/../views/list.php';
+        // ビューに渡す
+        require_once __DIR__ . '/../views/list.php';
+    }
+}
+
+// 実行
+$controller = new TodoController();
+$controller->handle();

--- a/controllers/Updatecontroller.php
+++ b/controllers/Updatecontroller.php
@@ -1,26 +1,30 @@
 <?php
-require_once __DIR__ . '/../config/config.php';
 require_once __DIR__ . '/../models/Todo.php';
 require_once __DIR__ . '/../helpers/Validation.php';
 
-$id = filter_input(INPUT_POST, 'id', FILTER_VALIDATE_INT);
-$title = trim($_POST['title'] ?? '');
-$content = trim($_POST['content'] ?? '');
+class UpdateController
+{
+    public function handle(): void
+    {
+        $id = filter_input(INPUT_POST, 'id', FILTER_VALIDATE_INT);
+        $title = trim($_POST['title'] ?? '');
+        $content = trim($_POST['content'] ?? '');
 
-// バリデーション
-$errors = validateTodoUpdateInput($id, $title, $content);
-if (!empty($errors)) {
-    foreach ($errors as $error) {
-        echo '<p style="color:red;">' . htmlspecialchars($error, ENT_QUOTES, 'UTF-8') . '</p>';
+        $errors = Validation::validateTodoUpdateInput($id, $title, $content);
+
+        if (!empty($errors)) {
+            require_once __DIR__ . '/../views/errors/update_error.php';
+            return;
+        }
+
+        $todoModel = new Todo();
+        $todoModel->update($id, $title, $content);
+
+        header('Location: /php-0416-training/index.php');
+        exit;
     }
-    echo '<a href="/php-0416-training/views/edit.php?id=' . htmlspecialchars($id) . '"><button>戻る</button></a>';
-    exit;
 }
 
-// DB更新
-$todoModel = new Todo();
-$todoModel->update($id, $title, $content);
-
-// 一覧画面にリダイレクト
-header('Location: /php-0416-training/index.php');
-exit;
+// 実行
+$controller = new UpdateController();
+$controller->handle();

--- a/create_action.php
+++ b/create_action.php
@@ -1,0 +1,5 @@
+<?php
+require_once __DIR__ . '/controllers/CreateController.php';
+
+$controller = new CreateController();
+$controller->handle();

--- a/helpers/Validation.php
+++ b/helpers/Validation.php
@@ -1,37 +1,49 @@
 <?php
 
-// 新規作成時のバリデーション（IDなし）
-function validateTodoInput(string $title, string $content): array
+class Validation
 {
-    $errors = [];
+    // TODO_COUNT→ToDoの最大件数
+    public const MAX_TODO_COUNT   = 20;
+    // TITLE_LENGTH→タイトルの最大字数
+    public const MAX_TITLE_LENGTH = 20;
+    // CONTENT_LENGTH→内容の最大字数
+    public const MAX_CONTENT_LENGTH = 50;
 
-    if (trim($title) === '') {
-        $errors[] = 'タイトルを入力してください。';
+    // 新規作成・編集用
+    public static function validateTodoInput(string $title, string $content, $todoCount = null): array
+    {
+        $errors = [];
+
+        if ($todoCount !== null && $todoCount >= self::MAX_TODO_COUNT) {
+            $errors[] = 'ToDoの最大件数（' . self::MAX_TODO_COUNT . '件）を超えています。これ以上タスクを増やす前に、既存のToDoを片付けましょう。';
+        }
+
+        if (trim($title) === '') {
+            $errors[] = 'タイトルを入力してください。';
+        } elseif (mb_strlen($title) > self::MAX_TITLE_LENGTH) {
+            $errors[] = 'タイトルは' . self::MAX_TITLE_LENGTH . '文字以内で入力してください。一目で何をすべきかがわかるタイトルが良いですよ。';
+        }
+
+        if (trim($content) === '') {
+            $errors[] = '内容を入力してください。';
+        } elseif (mb_strlen($content) > self::MAX_CONTENT_LENGTH) {
+            $errors[] = '内容は' . self::MAX_CONTENT_LENGTH . '文字以内で入力してください。' . self::MAX_CONTENT_LENGTH . '文字に抑えられない内容なら、タスクの分割化を検討した方がよいかもしれませんね。';
+        }
+
+        return $errors;
     }
 
-    if (trim($content) === '') {
-        $errors[] = '内容を入力してください。';
+    // 更新用のバリデーション
+    public static function validateTodoUpdateInput(?int $id, string $title, string $content): array
+    {
+        $errors = [];
+
+        if ($id === null || $id === false) {
+            $errors[] = '不正なIDです。';
+        }
+
+        $errors = array_merge($errors, self::validateTodoInput($title, $content));
+
+        return $errors;
     }
-
-    return $errors;
-}
-
-// 更新時のバリデーション（IDあり）
-function validateTodoUpdateInput($id, string $title, string $content): array
-{
-    $errors = [];
-
-    if (!is_numeric($id) || (int)$id <= 0) {
-        $errors[] = '不正な操作です。';
-    }
-
-    if (trim($title) === '') {
-        $errors[] = 'タイトルを入力してください。';
-    }
-
-    if (trim($content) === '') {
-        $errors[] = '内容を入力してください。';
-    }
-
-    return $errors;
 }

--- a/index.php
+++ b/index.php
@@ -3,7 +3,7 @@ error_reporting(E_ALL);
 ini_set('display_errors', 1);
 
 require_once __DIR__ . '/controllers/TodoController.php';
-$todoCount = count($todos);
+
 ?>
 
 <!DOCTYPE html>

--- a/views/create.php
+++ b/views/create.php
@@ -1,11 +1,21 @@
+<?php
+require_once __DIR__ . '/../helpers/Validation.php';
+
+// 定数を取得して変数化
+$maxTitleLength = (new ReflectionClass('Validation'))->getConstant('MAX_TITLE_LENGTH');
+$maxContentLength = (new ReflectionClass('Validation'))->getConstant('MAX_CONTENT_LENGTH');
+
+// ビューを読み込む
+require_once __DIR__ . '/../views/create.php';
+?>
+
 <h1>ToDo新規作成</h1>
-<form action="/php-0416-training/controllers/Createcontroller.php" method="POST">
-    <label>タイトル：</label><br>
+<form action="/php-0416-training/create_action.php" method="POST">
+    <label>タイトル（<?= htmlspecialchars($maxTitleLength, ENT_QUOTES, 'UTF-8') ?>文字以内）：</label><br>
     <input type="text" name="title" required><br><br>
 
-    <label>内容：</label><br>
+    <label>内容（<?= htmlspecialchars($maxContentLength, ENT_QUOTES, 'UTF-8') ?>文字以内）：</label><br>
     <textarea name="content" rows="4" cols="40" required></textarea><br><br>
 
     <input type="submit" value="作成">
-
 </form>

--- a/views/edit.php
+++ b/views/edit.php
@@ -1,13 +1,23 @@
+<?php
+require_once __DIR__ . '/../helpers/Validation.php';
+
+// 定数を取得して変数化
+$maxTitleLength = (new ReflectionClass('Validation'))->getConstant('MAX_TITLE_LENGTH');
+$maxContentLength = (new ReflectionClass('Validation'))->getConstant('MAX_CONTENT_LENGTH');
+
+// ビューを読み込む
+require_once __DIR__ . '/../views/edit.php';
+?>
+
 <h1>ToDo編集</h1>
 
 <form action="/php-0416-training/controllers/UpdateController.php" method="POST">
     <input type="hidden" name="id" value="<?= htmlspecialchars($todo['id']) ?>">
 
-    <label>タイトル：</label><br>
-    <input type="text" name="title" value="<?= htmlspecialchars($todo['title']) ?>" required><br><br>
+    <label>タイトル（<?= htmlspecialchars($maxTitleLength, ENT_QUOTES, 'UTF-8') ?>文字以内）：</label><br>
+    <input type="text" name="title" required><br><br>
 
-    <label>内容：</label><br>
-    <textarea name="content" rows="4" cols="40" required><?= htmlspecialchars($todo['content']) ?></textarea><br><br>
-
+    <label>内容（<?= htmlspecialchars($maxContentLength, ENT_QUOTES, 'UTF-8') ?>文字以内）：</label><br>
+    <textarea name="content" rows="4" cols="40" required></textarea><br><br>
     <input type="submit" value="更新">
 </form>

--- a/views/errors/create_error.php
+++ b/views/errors/create_error.php
@@ -1,0 +1,23 @@
+<!-- views/errors/create_error.php -->
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+    <meta charset="UTF-8">
+    <title>ERROR</title>
+    <style>
+        .error {
+            color: red;
+        }
+    </style>
+</head>
+
+<body>
+    <h2>ERROR</h2>
+    <?php foreach ($errors as $error): ?>
+        <p class="error"><?= htmlspecialchars($error, ENT_QUOTES, 'UTF-8') ?></p>
+    <?php endforeach; ?>
+    <a href="/php-0416-training/views/create.php"><button>戻る</button></a>
+</body>
+
+</html>

--- a/views/errors/update_error.php
+++ b/views/errors/update_error.php
@@ -1,0 +1,23 @@
+<!-- views/errors/update_error.php -->
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+    <meta charset="UTF-8">
+    <title>ERROR</title>
+    <style>
+        .error {
+            color: red;
+        }
+    </style>
+</head>
+
+<body>
+    <h2>ERROR</h2>
+    <?php foreach ($errors as $error): ?>
+        <p class="error"><?= htmlspecialchars($error, ENT_QUOTES, 'UTF-8') ?></p>
+    <?php endforeach; ?>
+    <a href="/php-0416-training/views/edit.php"><button>戻る</button></a>
+</body>
+
+</html>

--- a/views/list.php
+++ b/views/list.php
@@ -1,45 +1,48 @@
 <!DOCTYPE html>
 <html lang="ja">
-
+<head>
+    <meta charset="UTF-8">
+    <title>ToDoリスト</title>
+    <style>
+        .error {
+            color: red;
+            font-weight: bold;
+        }
+    </style>
+</head>
 <body>
-    <?php if (isset($_GET['error'])): ?>
-        <p class="error">
-            <?php
-            if ($_GET['error'] === 'invalid_id') echo 'ERROR：不正なIDが入力されました。';
-            if ($_GET['error'] === 'not_found') echo 'ERROR：指定されたToDoは見つかりませんでした。URLに誤りがあるか、既に削除されたToDoです。';
-            ?>
-        </p>
+
+    <h1>ToDoリスト</h1>
+
+    <?php if (!empty($errorMessage)): ?>
+        <p class="error"><?= htmlspecialchars($errorMessage) ?></p>
     <?php endif; ?>
 
+    <h3>ToDo数：<?= $todoCount ?>件</h3>
 
-    <meta charset="UTF-8">
-    <h1>ToDoリスト</h1>
-    <h3>ToDo数：<?= $todoCount ?> 件</h3>
-    <title>ToDoリスト</title>
     <a href="/php-0416-training/views/create.php">
         <button>新規作成</button>
     </a>
+
+    <?php foreach ($todos as $todo): ?>
+        <div style="display: flex; justify-content: space-between; align-items: center; padding: 8px; border-bottom: 1px solid #ccc;">
+            <div>
+                <h3>タイトル：<?= htmlspecialchars($todo['title']) ?></h3>
+                <p>内容：<?= nl2br(htmlspecialchars($todo['content'])) ?></p>
+                <p>作成日時：<?= nl2br(htmlspecialchars($todo['created_at'])) ?></p>
+                <p>更新日時：<?= nl2br(htmlspecialchars($todo['updated_at'])) ?></p>
+            </div>
+            <div>
+                <a href="/php-0416-training/controllers/EditController.php?id=<?= $todo['id'] ?>">
+                    <button>編集</button>
+                </a>
+                <form action="/php-0416-training/controllers/DeleteController.php" method="POST" style="display:inline;">
+                    <input type="hidden" name="id" value="<?= $todo['id'] ?>">
+                    <button type="submit" onclick="return confirm('このToDoを削除します。本当によろしいですか？')">削除</button>
+                </form>
+            </div>
+        </div>
+    <?php endforeach; ?>
+
 </body>
-
-<?php foreach ($todos as $todo): ?>
-    <div style="display: flex; justify-content: space-between; align-items: center; padding: 8px; border-bottom: 1px solid #ccc;">
-        <div>
-            <h3>タイトル：<?= htmlspecialchars($todo['title']) ?></h3>
-            <p>内容：<?= nl2br(htmlspecialchars($todo['content'])) ?></p>
-            <p>作成日時：<?= nl2br(htmlspecialchars($todo['created_at'])) ?></p>
-            <p>更新日時：<?= nl2br(htmlspecialchars($todo['updated_at'])) ?></p>
-        </div>
-        <div>
-            <a href="/php-0416-training/controllers/EditController.php?id=<?= $todo['id'] ?>">
-                <button>編集</button>
-            </a>
-            <form action="/php-0416-training/controllers/DeleteController.php" method="POST" style="display:inline;">
-                <input type="hidden" name="id" value="<?= $todo['id'] ?>">
-                <button type="submit" onclick="return confirm('このToDoを削除します。本当によろしいですか？')">削除</button>
-            </form>
-        </div>
-    </div>
-<?php endforeach; ?>
-
-
 </html>

--- a/views/list.php
+++ b/views/list.php
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="ja">
+
 <head>
     <meta charset="UTF-8">
     <title>ToDoリスト</title>
@@ -10,6 +11,7 @@
         }
     </style>
 </head>
+
 <body>
 
     <h1>ToDoリスト</h1>
@@ -45,4 +47,5 @@
     <?php endforeach; ?>
 
 </body>
+
 </html>


### PR DESCRIPTION
0421作業成果

日高さんのコメントを基にした修正

- バリデーションの強化・設定（作成件数20件以内、タイトル20文字以内、内容50文字以内）になるように設定
- ControllerとViewファイルの責務が被らないように分けた（SOLID原則・単一責任の原則）
- `.vscode/settings.json`をgitの管理下から外した
- 変数名を命名規則に則った形に修正
- 余計な部分を削除


要件別チェック

<基本要件>

一覧表示画面

- [x]     ToDoの一覧を作成日時の降順で表示できる。
- [x]     ToDoごとにタイトルと内容と作成日時と更新日時を表示できる。
- [x]     ToDoごとの右側に編集ボタンと削除ボタンを持つ。

新規作成機能

- [x]     フォームを持ち、タイトルと内容を入力できる。
- [x]     ToDoを新規作成できる。

編集機能

- [x]     編集ボタンを押して編集画面に移動できる。
- [x]     フォームを持ち、タイトルと内容を入力できる。
- [x]     ToDoを更新できる。

削除機能

- [x]     削除ボタンを押してToDoを削除できる。

セキュリティ対策

- [x]     SQLインジェクション対策がなされていること
- [x]     XSS対策がなされていること


<品質要件>

カプセル化
- [x]     情報を隠蔽できていること
- [x]     影響範囲を限定できていること
集約・SOLID原則
- [x]     概念を理解して使っていること
デザインパターン
- [x]     ストラテジーパターンを用いて処理が書かれていること。