### PR TITLE
0422作業成果

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-    "cSpell.words": [
-        "Createcontroller"
-
-    
-    ]
-}

--- a/controllers/Createcontroller.php
+++ b/controllers/Createcontroller.php
@@ -7,30 +7,34 @@ class CreateController
 {
     public function handle(): void
     {
-        // POSTデータの取得
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+            // 定数を取得してビューに渡す
+            $viewVars = [
+                'maxTitleLength' => Validation::MAX_TITLE_LENGTH,
+                'maxContentLength' => Validation::MAX_CONTENT_LENGTH,
+            ];
+            extract($viewVars);
+            require_once __DIR__ . '/../views/create.php';
+            return;
+        }
+
         $title = trim($_POST['title'] ?? '');
         $content = trim($_POST['content'] ?? '');
 
-        // Todoモデルのインスタンス生成
-        $todoModel = new Todo();
-
-        // ToDo数取得
-        $todos = $todoModel->getAllTodos();
-        $todoCount = count($todos);
-
-        // バリデーション
-        $errors = Validation::validateTodoInput($title, $content, $todoCount);
+        $errors = Validation::validateTodoInput($title, $content);
 
         if (!empty($errors)) {
             require_once __DIR__ . '/../views/errors/create_error.php';
             return;
         }
 
-        // 新規作成処理
+        $todoModel = new Todo();
         $todoModel->create($title, $content);
 
-        // 一覧ページへリダイレクト
         header('Location: /php-0416-training/index.php');
         exit;
     }
 }
+
+$controller = new CreateController();
+$controller->handle();

--- a/controllers/Deletecontroller.php
+++ b/controllers/Deletecontroller.php
@@ -20,6 +20,5 @@ class DeleteController
     }
 }
 
-// 実行
 $controller = new DeleteController();
 $controller->handle();

--- a/controllers/Editcontroller.php
+++ b/controllers/Editcontroller.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__ . '/../config/config.php';
 require_once __DIR__ . '/../models/Todo.php';
+require_once __DIR__ . '/../helpers/Validation.php';
 
 class EditController
 {
@@ -21,11 +22,17 @@ class EditController
             exit;
         }
 
-        // ビューに渡す
+        $viewVars = [
+            'todo' => $todo,
+            'maxTitleLength' => Validation::MAX_TITLE_LENGTH,
+            'maxContentLength' => Validation::MAX_CONTENT_LENGTH,
+        ];
+
+        extract($viewVars);
+
         require_once __DIR__ . '/../views/edit.php';
     }
 }
 
-// 実行
 $controller = new EditController();
 $controller->handle();

--- a/controllers/Storecontroller.php
+++ b/controllers/Storecontroller.php
@@ -28,6 +28,5 @@ class StoreController
     }
 }
 
-// 実行
 $controller = new StoreController();
 $controller->handle();

--- a/controllers/Todocontroller.php
+++ b/controllers/Todocontroller.php
@@ -14,6 +14,5 @@ class TodoController
     }
 }
 
-// 実行
 $controller = new TodoController();
 $controller->handle();

--- a/controllers/Updatecontroller.php
+++ b/controllers/Updatecontroller.php
@@ -13,9 +13,19 @@ class UpdateController
         $errors = Validation::validateTodoUpdateInput($id, $title, $content);
 
         if (!empty($errors)) {
+            $todo = (object)[
+                'id' => $id,
+                'title' => $title,
+                'content' => $content
+            ];
+        
+            $maxTitleLength = Validation::MAX_TITLE_LENGTH;
+            $maxContentLength = Validation::MAX_CONTENT_LENGTH;
+        
             require_once __DIR__ . '/../views/errors/update_error.php';
             return;
         }
+        
 
         $todoModel = new Todo();
         $todoModel->update($id, $title, $content);
@@ -25,6 +35,5 @@ class UpdateController
     }
 }
 
-// 実行
 $controller = new UpdateController();
 $controller->handle();

--- a/create_action.php
+++ b/create_action.php
@@ -1,5 +1,0 @@
-<?php
-require_once __DIR__ . '/controllers/CreateController.php';
-
-$controller = new CreateController();
-$controller->handle();

--- a/index.php
+++ b/index.php
@@ -3,25 +3,3 @@ error_reporting(E_ALL);
 ini_set('display_errors', 1);
 
 require_once __DIR__ . '/controllers/TodoController.php';
-
-?>
-
-<!DOCTYPE html>
-<html lang="ja">
-
-<head>
-    <meta charset="UTF-8">
-    <title>ToDo一覧</title>
-    <style>
-        body {
-            font-family: sans-serif;
-        }
-
-        .error {
-            color: red;
-            margin: 1em 0;
-        }
-    </style>
-</head>
-
-<body>

--- a/models/Todo.php
+++ b/models/Todo.php
@@ -40,8 +40,11 @@ class Todo
         $stmt = $this->pdo->prepare("SELECT * FROM todos WHERE id = :id");
         $stmt->bindParam(':id', $id, PDO::PARAM_INT);
         $stmt->execute();
-        return $stmt->fetch(PDO::FETCH_ASSOC);
+        $data = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $data ? new TodoEntity($data) : null;
     }
+
 
     public function update($id, $title, $content)
     {
@@ -65,5 +68,23 @@ class Todo
         $stmt = $this->pdo->prepare("DELETE FROM todos WHERE id = :id");
         $stmt->bindParam(':id', $id, PDO::PARAM_INT);
         return $stmt->execute();
+    }
+}
+
+class TodoEntity
+{
+    public int $id;
+    public string $title;
+    public string $content;
+    public string $created_at;
+    public string $updated_at;
+
+    public function __construct(array $data)
+    {
+        $this->id = (int) $data['id'];
+        $this->title = $data['title'];
+        $this->content = $data['content'];
+        $this->created_at = $data['created_at'];
+        $this->updated_at = $data['updated_at'];
     }
 }

--- a/views/create.php
+++ b/views/create.php
@@ -1,21 +1,64 @@
-<?php
-require_once __DIR__ . '/../helpers/Validation.php';
-
-// 定数を取得して変数化
-$maxTitleLength = (new ReflectionClass('Validation'))->getConstant('MAX_TITLE_LENGTH');
-$maxContentLength = (new ReflectionClass('Validation'))->getConstant('MAX_CONTENT_LENGTH');
-
-// ビューを読み込む
-require_once __DIR__ . '/../views/create.php';
-?>
-
 <h1>ToDo新規作成</h1>
-<form action="/php-0416-training/create_action.php" method="POST">
-    <label>タイトル（<?= htmlspecialchars($maxTitleLength, ENT_QUOTES, 'UTF-8') ?>文字以内）：</label><br>
-    <input type="text" name="title" required><br><br>
 
-    <label>内容（<?= htmlspecialchars($maxContentLength, ENT_QUOTES, 'UTF-8') ?>文字以内）：</label><br>
-    <textarea name="content" rows="4" cols="40" required></textarea><br><br>
+<form id="createForm" action="/php-0416-training/controllers/CreateController.php" method="POST">
+    <label>
+        タイトル（<span id="titleLength">0</span>/<?= htmlspecialchars($maxTitleLength, ENT_QUOTES, 'UTF-8') ?>文字）：
+    </label><br>
+    <input type="text" name="title" id="titleInput" required><br><br>
 
-    <input type="submit" value="作成">
+    <label>
+        内容（<span id="contentLength">0</span>/<?= htmlspecialchars($maxContentLength, ENT_QUOTES, 'UTF-8') ?>文字）：
+    </label><br>
+    <textarea name="content" id="contentInput" rows="4" cols="40" required></textarea><br><br>
+
+    <input type="submit" id="submitBtn" value="作成">
 </form>
+
+<style>
+    .over-limit {
+        color: red;
+        font-weight: bold;
+    }
+</style>
+
+<script>
+    const titleInput = document.getElementById('titleInput');
+    const contentInput = document.getElementById('contentInput');
+    const titleLength = document.getElementById('titleLength');
+    const contentLength = document.getElementById('contentLength');
+    const submitBtn = document.getElementById('submitBtn');
+
+    const maxTitle = <?= $maxTitleLength ?>;
+    const maxContent = <?= $maxContentLength ?>;
+
+    function updateLengthDisplay(input, display, max) {
+        const len = input.value.length;
+        display.textContent = len;
+        if (len > max) {
+            display.classList.add('over-limit');
+        } else {
+            display.classList.remove('over-limit');
+        }
+        checkFormValidity();
+    }
+
+    function checkFormValidity() {
+        const isTitleValid = titleInput.value.length <= maxTitle;
+        const isContentValid = contentInput.value.length <= maxContent;
+        submitBtn.disabled = !(isTitleValid && isContentValid);
+    }
+
+    // 初期表示時チェック
+    document.addEventListener('DOMContentLoaded', () => {
+        updateLengthDisplay(titleInput, titleLength, maxTitle);
+        updateLengthDisplay(contentInput, contentLength, maxContent);
+    });
+
+    titleInput.addEventListener('input', () => {
+        updateLengthDisplay(titleInput, titleLength, maxTitle);
+    });
+
+    contentInput.addEventListener('input', () => {
+        updateLengthDisplay(contentInput, contentLength, maxContent);
+    });
+</script>

--- a/views/edit.php
+++ b/views/edit.php
@@ -1,23 +1,65 @@
-<?php
-require_once __DIR__ . '/../helpers/Validation.php';
-
-// 定数を取得して変数化
-$maxTitleLength = (new ReflectionClass('Validation'))->getConstant('MAX_TITLE_LENGTH');
-$maxContentLength = (new ReflectionClass('Validation'))->getConstant('MAX_CONTENT_LENGTH');
-
-// ビューを読み込む
-require_once __DIR__ . '/../views/edit.php';
-?>
-
 <h1>ToDo編集</h1>
 
-<form action="/php-0416-training/controllers/UpdateController.php" method="POST">
-    <input type="hidden" name="id" value="<?= htmlspecialchars($todo['id']) ?>">
+<form id="editForm" action="/php-0416-training/controllers/UpdateController.php" method="POST">
+    <input type="hidden" name="id" value="<?= htmlspecialchars($todo->id) ?>">
 
-    <label>タイトル（<?= htmlspecialchars($maxTitleLength, ENT_QUOTES, 'UTF-8') ?>文字以内）：</label><br>
-    <input type="text" name="title" required><br><br>
+    <label>
+        タイトル（<span id="titleLength"><?= mb_strlen($todo->title) ?></span>/<?= $maxTitleLength ?>文字）：
+    </label><br>
+    <input type="text" name="title" id="titleInput"
+        value="<?= htmlspecialchars($todo->title, ENT_QUOTES, 'UTF-8') ?>" required><br><br>
 
-    <label>内容（<?= htmlspecialchars($maxContentLength, ENT_QUOTES, 'UTF-8') ?>文字以内）：</label><br>
-    <textarea name="content" rows="4" cols="40" required></textarea><br><br>
-    <input type="submit" value="更新">
+    <label>
+        内容（<span id="contentLength"><?= mb_strlen($todo->content) ?></span>/<?= $maxContentLength ?>文字）：
+    </label><br>
+    <textarea name="content" id="contentInput" rows="4" cols="40" required><?= htmlspecialchars($todo->content, ENT_QUOTES, 'UTF-8') ?></textarea><br><br>
+
+    <input type="submit" id="submitBtn" value="更新">
 </form>
+
+<style>
+    .over-limit {
+        color: red;
+        font-weight: bold;
+    }
+</style>
+
+<script>
+    const titleInput = document.getElementById('titleInput');
+    const contentInput = document.getElementById('contentInput');
+    const titleLength = document.getElementById('titleLength');
+    const contentLength = document.getElementById('contentLength');
+    const submitBtn = document.getElementById('submitBtn');
+
+    const maxTitle = <?= $maxTitleLength ?>;
+    const maxContent = <?= $maxContentLength ?>;
+
+    function updateLengthDisplay(input, display, max) {
+        const len = input.value.length;
+        display.textContent = len;
+        if (len > max) {
+            display.classList.add('over-limit');
+        } else {
+            display.classList.remove('over-limit');
+        }
+        checkFormValidity();
+    }
+
+    function checkFormValidity() {
+        const isTitleValid = titleInput.value.length <= maxTitle;
+        const isContentValid = contentInput.value.length <= maxContent;
+        submitBtn.disabled = !(isTitleValid && isContentValid);
+    }
+
+
+    updateLengthDisplay(titleInput, titleLength, maxTitle);
+    updateLengthDisplay(contentInput, contentLength, maxContent);
+
+    titleInput.addEventListener('input', () => {
+        updateLengthDisplay(titleInput, titleLength, maxTitle);
+    });
+
+    contentInput.addEventListener('input', () => {
+        updateLengthDisplay(contentInput, contentLength, maxContent);
+    });
+</script>

--- a/views/errors/create_error.php
+++ b/views/errors/create_error.php
@@ -17,7 +17,8 @@
     <?php foreach ($errors as $error): ?>
         <p class="error"><?= htmlspecialchars($error, ENT_QUOTES, 'UTF-8') ?></p>
     <?php endforeach; ?>
-    <a href="/php-0416-training/views/create.php"><button>戻る</button></a>
+    <a href="/php-0416-training/controllers/CreateController.php"><button>戻る</button></a>
+
 </body>
 
 </html>

--- a/views/errors/update_error.php
+++ b/views/errors/update_error.php
@@ -1,4 +1,3 @@
-<!-- views/errors/update_error.php -->
 <!DOCTYPE html>
 <html lang="ja">
 
@@ -17,7 +16,10 @@
     <?php foreach ($errors as $error): ?>
         <p class="error"><?= htmlspecialchars($error, ENT_QUOTES, 'UTF-8') ?></p>
     <?php endforeach; ?>
-    <a href="/php-0416-training/views/edit.php"><button>戻る</button></a>
+    <a href="/php-0416-training/controllers/EditController.php?id=<?= htmlspecialchars($todo->id, ENT_QUOTES, 'UTF-8') ?>">
+        <button>戻る</button>
+    </a>
+
 </body>
 
 </html>

--- a/views/list.php
+++ b/views/list.php
@@ -3,16 +3,25 @@
 
 <head>
     <meta charset="UTF-8">
-    <title>ToDoリスト</title>
+
+    <?php if (isset($_GET['error'])): ?>
+        <p class="error">
+            <?php
+            if ($_GET['error'] === 'invalid_id') {
+                echo '不正なIDが入力されました。';
+            } elseif ($_GET['error'] === 'not_found') {
+                echo '指定されたToDoは見つかりませんでした。既に削除された可能性もあります。';
+            }
+            ?>
+        </p>
+    <?php endif; ?>
+
     <style>
         .error {
             color: red;
             font-weight: bold;
         }
     </style>
-</head>
-
-<body>
 
     <h1>ToDoリスト</h1>
 
@@ -22,7 +31,7 @@
 
     <h3>ToDo数：<?= $todoCount ?>件</h3>
 
-    <a href="/php-0416-training/views/create.php">
+    <a href="/php-0416-training/controllers/CreateController.php">
         <button>新規作成</button>
     </a>
 
@@ -47,5 +56,6 @@
     <?php endforeach; ?>
 
 </body>
+
 
 </html>


### PR DESCRIPTION
0422作業成果

日高さんのコメントを基にした修正

- `settings.json`を.`gitignore`対応した。
- `create_action.php`を消去し、`create.php`の中で完結するようにした。
- コントローラーがフロントエンド（ビュー）へ必要な定数を渡すように設定。
- 自身を参照してしまっていたものは消去した。
- `Todo::findById()` などモデルから取得したデータを、クラスのインスタンスとして返すように実装。

追加
-  ToDoの新規作成・編集において、現在入力されている文字数を表示。
- バリデーションの強化。具体的には、作成・更新時において規定の文字数をオーバーしていた場合、作成・更新ボタンが押せないような仕様にした。


要件別チェック

<基本要件>

一覧表示画面

- [x]     ToDoの一覧を作成日時の降順で表示できる。
- [x]     ToDoごとにタイトルと内容と作成日時と更新日時を表示できる。
- [x]     ToDoごとの右側に編集ボタンと削除ボタンを持つ。

新規作成機能

- [x]     フォームを持ち、タイトルと内容を入力できる。
- [x]     ToDoを新規作成できる。

編集機能

- [x]     編集ボタンを押して編集画面に移動できる。
- [x]     フォームを持ち、タイトルと内容を入力できる。
- [x]     ToDoを更新できる。

削除機能

- [x]     削除ボタンを押してToDoを削除できる。

セキュリティ対策

- [x]     SQLインジェクション対策がなされていること
- [x]     XSS対策がなされていること


<品質要件>

カプセル化
- [x]     情報を隠蔽できていること
- [x]     影響範囲を限定できていること
集約・SOLID原則
- [x]     概念を理解して使っていること
デザインパターン
- [x]     ストラテジーパターンを用いて処理が書かれていること。